### PR TITLE
fix: corrected inverted filtering logic in selectFilteredNotes

### DIFF
--- a/src/redux/notes-state/selectors.js
+++ b/src/redux/notes-state/selectors.js
@@ -9,11 +9,11 @@ export const selectAllNotes = createSelector(
 );
 
 export const selectFilteredNotes = createSelector(
-  [selectAllNotes, state => state.notes.filter],
+  [selectAllNotes, (state) => state.notes.filter],
   (notes, filter) => {
-    if (filter === 'all') return notes;
+    if (filter === "all") return notes;
     const typeValue = TYPE_MAP[filter];
-    return notes.filter(note => note.type !== typeValue);
+    return notes.filter((note) => note.type === typeValue);
   }
 );
 


### PR DESCRIPTION
- Error excluded notes of the selected type instead of including them
- Now properly filters notes where note.type === typeValue
- Bug caused unexpected results when applying filters from dropdown